### PR TITLE
doc: add CONTRIBUTING.md page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See https://github.com/distributeaid#%EF%B8%8F-contributing


### PR DESCRIPTION
This creates a CONTRIBUTING.md page that links to the main CONTRIBUTING.md for Distribute Aid.

Closes #7