### PR TITLE
doc: add status definitions

### DIFF
--- a/distro-force-docs/status-definitions.md
+++ b/distro-force-docs/status-definitions.md
@@ -1,0 +1,38 @@
+# Status definitions
+
+This document defines the different stages of the shipment status.
+
+## Proposed
+
+This status represents new shipments that have been requested by an organization.
+The profile for the shipment will be created in this stage.
+
+## Planning
+
+Shipments with this status are being prepared for shipping.
+
+## Shipping
+
+Shipments with this status are currently in transit to their destination. 
+
+## Documentation
+
+Shipments with this status have arrived at the final destination
+and are being documented. This also includes checking with the receiving organization
+to ensure that everything is in order.
+
+## Completed
+
+Shipments with this status have been distributed to the receiving organization
+and have all their paperwork completed.
+
+## Completed Transfer/Assistance
+
+## Paused/Held
+
+Shipments with this status have been placed on hold
+and are being reviewed.
+
+## Cancelled
+
+Shipments with this status have been cancelled.


### PR DESCRIPTION
add status definitions for:

- [x] Proposed
- [x] Planning
- [x] Shipping
- [x] Documentation
- [x] Completed 
- [ ] Completed Transfer/Assistance
- [x] Paused/Held
- [x] Cancelled